### PR TITLE
fix: disable toast auto focus

### DIFF
--- a/src/components/ui/toaster.jsx
+++ b/src/components/ui/toaster.jsx
@@ -35,12 +35,15 @@ export const toaster = createToaster({
   pauseOnPageIdle: true,
 });
 
+const baseCreate = toaster.create;
+toaster.create = (options) => baseCreate({ ...options, autoFocus: false });
+
 export const Toaster = () => {
   return (
     <Portal>
       <ChakraToaster toaster={toaster} insetInline={{ mdDown: "4" }}>
         {(toast) => (
-          <Toast.Root width={{ md: "sm" }}>
+          <Toast.Root tabIndex={-1} width={{ md: "sm" }}>
             {toast.type === "loading" ? (
               <Spinner size="sm" color="blue.solid" />
             ) : (


### PR DESCRIPTION
## Summary
- ensure toasts don't steal focus
- prevent toast element from becoming tab stop

## Testing
- `npm test` *(fails: missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8a79923c4832fac35d057698736b3